### PR TITLE
Add Subject-wise Analytics API, route binding, and response structure

### DIFF
--- a/backend/routes/dashboardRoutes.js
+++ b/backend/routes/dashboardRoutes.js
@@ -5,4 +5,7 @@ const dashboardController = require('../controllers/dashboardController');
 // GET /api/dashboard/semester/:semesterId
 router.get('/semester/:semesterId', dashboardController.getSemesterAnalytics);
 
+// GET /api/dashboard/subject/:subjectId
+router.get('/subject/:subjectId', dashboardController.getSubjectAnalytics);
+
 module.exports = router;


### PR DESCRIPTION
# Subject Dashboard Analytics API — New Endpoint Added

## New Route Added
### `GET /api/dashboard/subject/:subjectId`
Returns a structured analytics report for an individual subject.

---

## How to Test the Endpoint
### Request
```
GET /api/dashboard/subject/:subjectId
```

### Example
```
GET /api/dashboard/subject/6921823aa02ad32eafc5ae85
```

## Screenshot (Sample Response)
![Screenshot](https://github.com/user-attachments/assets/f08eaf9f-e2b2-429b-b499-a1d9a1955618)

---

## Files Modified
- `routes/dashboardRoutes.js`
- `controllers/dashboardController.js`

---
